### PR TITLE
Fix hang on close & crash on settings for NPP x64 (in DllMain.cpp)

### DIFF
--- a/src/DllMain.cpp
+++ b/src/DllMain.cpp
@@ -98,7 +98,7 @@ std::vector <SuggestionsMenuItem *> *MenuList = NULL;
 // Ok, trying to use window subclassing to handle messages
 LRESULT CALLBACK SubWndProcNotepad(HWND hWnd, UINT Message, WPARAM wParam, LPARAM lParam)
 {
-  int ret;
+  LRESULT ret; // int->LRESULT, fix x64 issue, still compatible with x86
   switch (Message)
   {
   case WM_INITMENUPOPUP:
@@ -266,7 +266,8 @@ extern "C" __declspec (dllexport) void beNotified (SCNotification *notifyCode)
 
         pluginCleanUp();
         if (wndProcNotepad != NULL)
-          ::SetWindowLongPtr (nppData._nppHandle, GWL_WNDPROC, (LONG)wndProcNotepad); // Removing subclassing
+          // LONG_PTR is more x64 friendly, yet not affecting x86
+          ::SetWindowLongPtr (nppData._nppHandle, GWL_WNDPROC, (LONG_PTR)wndProcNotepad); // Removing subclassing
       }
       break;
 


### PR DESCRIPTION
Please release a build which incorporates the following fix from edwpang for crash on settings (#76) and hang on close (which fully or partially fix #53 )

Fixes x64 crash issues:
1. Crash in setting dialog when built as x64 in NPP x64
2. Crash when closing NPP x64

@Predelnik @edwpang 