### PR TITLE
use GWLP_USERDATA and GWLP_WNDPROC

### DIFF
--- a/src/Controls/StaticDialog/StaticDialog.cpp
+++ b/src/Controls/StaticDialog/StaticDialog.cpp
@@ -136,7 +136,7 @@ BOOL CALLBACK StaticDialog::dlgProc(HWND hwnd, UINT message, WPARAM wParam, LPAR
 
   default :
     {
-      StaticDialog *pStaticDlg = reinterpret_cast<StaticDialog *>(::GetWindowLongPtr(hwnd, GWL_USERDATA));
+      StaticDialog *pStaticDlg = reinterpret_cast<StaticDialog *>(::GetWindowLongPtr(hwnd, GWLP_USERDATA));
       if (!pStaticDlg)
         return FALSE;
       return pStaticDlg->run_dlgProc(message, wParam, lParam);

--- a/src/Controls/TabBar/TabBar.h
+++ b/src/Controls/TabBar/TabBar.h
@@ -233,7 +233,7 @@ protected:
   LRESULT runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam);
 
   static LRESULT CALLBACK TabBarPlus_Proc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam) {
-    return (((TabBarPlus *)(::GetWindowLongPtr(hwnd, GWL_USERDATA)))->runProc(hwnd, Message, wParam, lParam));
+    return (((TabBarPlus *)(::GetWindowLongPtr(hwnd, GWLP_USERDATA)))->runProc(hwnd, Message, wParam, lParam));
   };
   void exchangeItemData(POINT point);
 

--- a/src/DllMain.cpp
+++ b/src/DllMain.cpp
@@ -211,7 +211,7 @@ extern "C" __declspec(dllexport) void setInfo(NppData notpadPlusData)
 {
   nppData = notpadPlusData;
   commandMenuInit();
-  wndProcNotepad = (WNDPROC)::SetWindowLongPtr(nppData._nppHandle, GWL_WNDPROC, (LPARAM)SubWndProcNotepad);
+  wndProcNotepad = (WNDPROC)::SetWindowLongPtr(nppData._nppHandle, GWLP_WNDPROC, (LPARAM)SubWndProcNotepad);
 }
 
 extern "C" __declspec(dllexport) const TCHAR *getName()
@@ -267,7 +267,7 @@ extern "C" __declspec (dllexport) void beNotified (SCNotification *notifyCode)
         pluginCleanUp();
         if (wndProcNotepad != NULL)
           // LONG_PTR is more x64 friendly, yet not affecting x86
-          ::SetWindowLongPtr (nppData._nppHandle, GWL_WNDPROC, (LONG_PTR)wndProcNotepad); // Removing subclassing
+          ::SetWindowLongPtr (nppData._nppHandle, GWLP_WNDPROC, (LONG_PTR)wndProcNotepad); // Removing subclassing
       }
       break;
 


### PR DESCRIPTION
, instead of old GWL_USERDATA and GWL_WNDPROC with GetWindowLongPtr/SetWindowLongPtr.
Also needed for x64 builds of DSpellCheck
