### PR TITLE
fix for recommendation message on winsock2

### DIFF
--- a/deps/FtpClient/Definements.h
+++ b/deps/FtpClient/Definements.h
@@ -22,6 +22,7 @@
 #endif
 
 #ifdef WIN32
+   #include <winsock2.h>
    #include <windows.h>
    #if _MSC_VER < 1500
       #define override


### PR DESCRIPTION
See build output, e.g. https://ci.appveyor.com/project/Predelnik/dspellcheck/build/1.340/job/ooe1cp0luf93rhxq

C:\projects\dspellcheck\deps\FtpClient\FTPFileStatus.cpp C:\projects\dspellcheck\deps\FtpClient\FTPListParse.cpp
  BlockingSocket.cpp

  It is recommended to include 'winsock2.h' instead of 'winsock.h'

  FTPClient.cpp

  It is recommended to include 'winsock2.h' instead of 'winsock.h'

C:\projects\dspellcheck\deps\FtpClient\FTPClient.cpp(283): warning C4244: '=': conversion from 'wchar_t' to 'char', possible loss of data [C:\projects\dspellcheck\_build_x86\deps\FtpClient\ftpclient.vcxproj]
  FTPDataTypes.cpp