### PR TITLE
Fixed some coding mistakes

### DIFF
--- a/src/AspellInterface.cpp
+++ b/src/AspellInterface.cpp
@@ -146,7 +146,7 @@ void AspellInterface::AddToDictionary(const char* Word) {
 
     if (!LastSelectedSpeller)
         return;
-    aspell_speller_add_to_personal(LastSelectedSpeller, Word, static_cast<int>(strlen(Word)) + 1);
+    aspell_speller_add_to_personal(LastSelectedSpeller, TargetWord.c_str(), static_cast<int>(TargetWord.length()) + 1);
     aspell_speller_save_all_word_lists(LastSelectedSpeller);
     if (aspell_speller_error(LastSelectedSpeller) != nullptr) {
         MessageBox(NppWindow, to_wstring (aspell_speller_error_message(LastSelectedSpeller)).c_str (), 
@@ -180,7 +180,7 @@ bool AspellInterface::CheckWord(const char* Word) {
     if (!AspellLoaded)
         return true;
 
-    std::string DstWord = nullptr;
+    std::string DstWord;
     bool res = false;
     if (CurrentEncoding == ENCODING_UTF8)
         DstWord = Word;

--- a/src/CommonFunctions.cpp
+++ b/src/CommonFunctions.cpp
@@ -198,7 +198,7 @@ std::wstring parseString(const wchar_t* source)
     wchar_t* str = nullptr;
     SetParsedString(str, source);
     std::wstring ret = str;
-    delete str;
+    delete[] str;
     return ret;
 }
 

--- a/src/Controls/TabBar/ControlsTab.h
+++ b/src/Controls/TabBar/ControlsTab.h
@@ -48,7 +48,7 @@ typedef std::vector<DlgInfo> WindowVector;
 class ControlsTab : public TabBar
 {
 public :
-  ControlsTab() : TabBar(), _pWinVector(NULL), _current(0), _isVertical(false) {};
+  ControlsTab() : TabBar(), _pWinVector(NULL), _current(0){};
   ~ControlsTab(){};
 
   void initTabBar(HINSTANCE hInst, HWND hwnd, bool isVertical = false, bool isTraditional = false, bool isMultiLine = false) override {
@@ -75,7 +75,6 @@ public :
 private :
   WindowVector *_pWinVector;
   int _current;
-  bool _isVertical;
 };
 
 #endif //CONTROLS_TAB_H

--- a/src/Controls/TabBar/TabBar.h
+++ b/src/Controls/TabBar/TabBar.h
@@ -66,7 +66,7 @@ struct TBHDR {
 class TabBar : public Window
 {
 public:
-  TabBar() : Window(), _nbItem(0), _hasImgLst(false), _hFont(NULL){};
+  TabBar() : Window(), _nbItem(0), _hasImgLst(false), _hFont(NULL), _isVertical(false) {};
   virtual ~TabBar() {};
   virtual void destroy();
   virtual void initTabBar(HINSTANCE hInst, HWND hwnd, bool isVertical = false, bool isTraditional = false, bool isMultiLine = false);

--- a/src/HunspellInterface.cpp
+++ b/src/HunspellInterface.cpp
@@ -542,7 +542,6 @@ void HunspellInterface::SetDirectory(const wchar_t* Dir) {
 
     DicDir = Dir;
 
-    std::set<AvailableLangInfo>::iterator it;
     dicList.clear();
     IsHunspellWorking = true;
 


### PR DESCRIPTION
1. AspellInterface.cpp
           - Instead of formal parameter ```Word```, local ```TargetWord``` should have been used. FYI, same thing can been seen in another method ```IgnoreAll```.
           - ```std::string DstWord``` should have some value, but neither ```NULL``` nor ```nullptr```.

2. CommonFunctions.cpp
           ```wchar_t* str``` is being allocated using ```new[]``` in method ```SetParsedString```, so it should be deleted using ```delete[]```.

3. ControlsTab.h & tabbar.h
           ``_isVertical``` is already member of base class ```TabBar``` so why do we need to declare again in derived class.

4. HunspellInterface.cpp
           Deleted unused variable.