### PR TITLE
Enables spell checking single-quoted Lua strings.

### DIFF
--- a/src/SciUtils.cpp
+++ b/src/SciUtils.cpp
@@ -222,6 +222,7 @@ namespace SciUtils
             case SCE_LUA_COMMENTDOC:
                 return s::comment;
             case SCE_LUA_STRING:
+            case SCE_LUA_CHARACTER:
             case SCE_LUA_LITERALSTRING:
                 return s::string;
             case SCE_LUA_IDENTIFIER:


### PR DESCRIPTION
A fix for https://github.com/Predelnik/DSpellCheck/issues/175

Treats "SCE_LUA_CHARACTER" as a string for spell-checking purposes. See [Scintilla's LexLua.cxx](https://github.com/geany/geany/blob/master/scintilla/lexers/LexLua.cxx#L484)