### PR TITLE
Fix crash when opening a large one-line file (500MB) on 32-bit, and improve loading time

### DIFF
--- a/src/core/SpellChecker.h
+++ b/src/core/SpellChecker.h
@@ -66,8 +66,9 @@ private:
   TextPosition prev_token_begin_in_document(TextPosition start) const;
   TextPosition next_token_end_in_document(TextPosition end) const;
   MappedWstring get_visible_text();
+  void underline_misspelled_words_in_visible_text();
   std::vector<SpellerWordData> check_text(const MappedWstring &text_to_check) const;
-  void underline_misspelled_words(const MappedWstring &text_to_check) const;
+  void underline_misspelled_words(const MappedWstring &text_to_check, const TextPosition start_pos) const;
   std::vector<std::wstring_view> get_misspelled_words(const MappedWstring &text_to_check) const;
   std::optional<std::array<TextPosition, 2>> find_first_misspelling(const MappedWstring &text_to_check, TextPosition last_valid_position) const;
   std::optional<std::array<TextPosition, 2>> find_last_misspelling(const MappedWstring &text_to_check, TextPosition last_valid_position) const;

--- a/src/npp/EditorInterface.cpp
+++ b/src/npp/EditorInterface.cpp
@@ -74,11 +74,3 @@ MappedWstring EditorInterface::get_mapped_wstring_range(TextPosition from, TextP
     val += from;
   return result;
 }
-
-MappedWstring EditorInterface::get_mapped_wstring_line(TextPosition line) {
-  auto result = to_mapped_wstring(get_line(line));;
-  auto line_start = get_line_start_position(line);
-  for (auto &val : result.mapping)
-    val += line_start;
-  return result;
-}

--- a/src/npp/EditorInterface.h
+++ b/src/npp/EditorInterface.h
@@ -132,8 +132,8 @@ public:
   TextPosition get_next_valid_end_pos(TextPosition pos) const;
   MappedWstring to_mapped_wstring(const std::string &str);
   MappedWstring get_mapped_wstring_range(TextPosition from, TextPosition to);
-  MappedWstring get_mapped_wstring_line(TextPosition line);
   std::string to_editor_encoding(std::wstring_view str) const;
+  virtual int get_first_visible_column() const = 0;
 
   virtual ~EditorInterface() = default;
 

--- a/src/npp/NppInterface.cpp
+++ b/src/npp/NppInterface.cpp
@@ -53,6 +53,12 @@ int NppInterface::get_indicator_value_at(int indicator_id, TextPosition position
   return static_cast<int>(send_msg_to_scintilla(SCI_INDICATORVALUEAT, indicator_id, position));
 }
 
+int NppInterface::get_first_visible_column() const {
+  const int x_offset = static_cast<int>(send_msg_to_scintilla(SCI_GETXOFFSET));
+  const int pixel_width = static_cast<int>(send_msg_to_scintilla(SCI_TEXTWIDTH, STYLE_DEFAULT, reinterpret_cast<LPARAM>("P")));
+  return static_cast<int>(x_offset / pixel_width);
+}
+
 LRESULT NppInterface::send_msg_to_npp(UINT Msg, WPARAM wParam, LPARAM lParam) const { return SendMessage(m_npp_data.npp_handle, Msg, wParam, lParam); }
 
 HWND NppInterface::get_view_hwnd() const {

--- a/src/npp/NppInterface.h
+++ b/src/npp/NppInterface.h
@@ -109,6 +109,8 @@ public:
   HMENU get_menu_handle(int menu_type) const;
   int get_target_view() const override;
   int get_indicator_value_at(int indicator_id, TextPosition position) const override;
+  int get_first_visible_column() const override;
+
   HWND get_view_hwnd() const override;
   std::wstring get_editor_directory() const override;
 

--- a/test/MockEditorInterface.cpp
+++ b/test/MockEditorInterface.cpp
@@ -718,6 +718,14 @@ void MockEditorInterface::set_mouse_cursor_pos(const std::optional<POINT> &pos) 
 
 std::wstring MockEditorInterface::get_editor_directory() const { return {}; }
 
+int MockEditorInterface::get_first_visible_column() const {
+  return m_first_visible_column;
+}
+
+void MockEditorInterface::scroll_horizontally(const int scroll_amount) {
+  m_first_visible_column += scroll_amount;
+}
+
 MockedDocumentInfo *MockEditorInterface::active_document() {
   if (m_documents[m_target_view].empty())
     return nullptr;

--- a/test/MockEditorInterface.h
+++ b/test/MockEditorInterface.h
@@ -142,6 +142,8 @@ public:
   std::optional<POINT> get_mouse_cursor_pos() const override;
   void set_mouse_cursor_pos(const std::optional<POINT> &pos);
   std::wstring get_editor_directory() const override;
+  int get_first_visible_column() const override;
+  void scroll_horizontally(const int scroll_amount);
 
 private:
   void set_target_view(int view_index) const override;
@@ -162,4 +164,5 @@ private:
   mutable int m_target_view = -1;
   RECT m_editor_rect;
   std::optional<POINT> m_cursor_pos;
+  int m_first_visible_column = 0;
 };


### PR DESCRIPTION
Problem:
32-bit Notepad++ crashes when opening large one-line files. 
Example issue: https://github.com/notepad-plus-plus/notepad-plus-plus/issues/11427

Steps to reproduce problem:
Take the file from https://github.com/notepad-plus-plus/notepad-plus-plus/issues/10407#issuecomment-902697944
Duplicate it's contents on the same line until you have a 500 MB file.
Try to open it on 32-bit N++. It should crash.

Problem in code:
Calling get_mapped_wstring_range for the entire 500MB line, results in placing 500MB in one single buffer. With 32-bit, this crashes. With 64-bit, it's very slow.

Proposed fix:
Merged and modified get_visible_text and underline_misspelled_words
        Doesn't get the entire line at once, instead it now works in blocks of 4096 characters
	Takes into account visible lines, horizontal scroll, and the end of the visible text in a line

Changed is_word_under_cursor_correct to check prev token and next token from the current position instead of using the entire line
	Also added a protection for when the document isn't loaded by N++


Result of fix:
No crash, and a loading time of around 30 seconds in Debug. N++ might not render the file, but at least it's not crashing.


Worked on this a month ago, and ended up leaving it on the side when I started looking at other functions that are taking too much into memory, and which also crash (or throw a "bad allocation" exception):
erase_all_misspellings
get_all_misspellings_as_string
mark_lines_with_misspelling

Don't think I'll have time to work on them, though.