### PR TITLE
Add DSPELLCHECK_GETLANGUAGELIST_MSG to get language list

### DIFF
--- a/include/PluginMsg.h
+++ b/include/PluginMsg.h
@@ -1,9 +1,16 @@
 #pragma once
 
-#define DSPELLCHECK_SETLANG_MSG 1
+#define DSPELLCHECK_SETLANG_MSG 1         // See DSpellCheckSetLangMsgInfo
+#define DSPELLCHECK_GETLANGUAGELIST_MSG 2 // See DSpellCheckGetLanguageListMsgInfo
 
-struct DSpellCheckSetLangMsgInfo
-{
+// Set language to lang_name, if was_success non-zero, it will be set to true in case of success and fales in case of failure
+struct DSpellCheckSetLangMsgInfo {
   const wchar_t *lang_name;
   bool *was_success; // optional out param, pointed bool set to true if language was switched
+};
+
+// language_callback will be called once for each language with payload provided as a second struct element
+struct DSpellCheckGetLanguageListMsgInfo {
+  void (*language_callback)(void *payload, const wchar_t *lang_name);
+  void *payload;
 };

--- a/src/plugin/Plugin.cpp
+++ b/src/plugin/Plugin.cpp
@@ -898,6 +898,15 @@ bool process_internal_msg(const CommunicationInfo& communication_info) {
     }
     }
     break;
+    case DSPELLCHECK_GETLANGUAGELIST_MSG: {
+      if (const auto info = reinterpret_cast<DSpellCheckGetLanguageListMsgInfo *>(communication_info.info)) {
+          const auto lang_list = speller_container->active_speller().get_language_list();
+          for (auto &lang : lang_list) {
+            info->language_callback(info->payload, lang.orig_name.c_str());
+          }
+        }
+      }
+      return true;
   }
   return false;
 }


### PR DESCRIPTION
Have chosen slightly unconventional api but it lets plugin avoid dealing with memory allocations. Here's the draft with example of interaction:
https://github.com/Predelnik/DSpellCheck/wiki/API-for-interaction-from-other-plugins#dspellcheck_getlanguagelist_msg

Solves #339